### PR TITLE
Fix updateUI crash from removed resource elements

### DIFF
--- a/app.js
+++ b/app.js
@@ -997,10 +997,7 @@ document.getElementById('xp').textContent = gameState.xp;
 document.getElementById('xp-next').textContent = gameState.xpToNext;
 document.getElementById('season').textContent = `${seasons[gameState.season].icon} ${seasons[gameState.season].name}`;
 
-// Update resources
-Object.keys(gameState.resources).forEach(resource => {
-    document.getElementById(resource).textContent = gameState.resources[resource];
-});
+// Update resources bar
 updateResourceBar();
 
 


### PR DESCRIPTION
## Summary
- prevent `updateUI` from querying obsolete resource elements

## Testing
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_685f077be7f883209b0fd1ac629a1c18