### PR TITLE
Add dynamic daily challenges

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
             <h2>Exploration</h2>
             <div class="exploration-info">
                 <p>Explorations remaining today: <span id="explorations-left">5</span>/5</p>
-                <p>Daily Challenge: <span id="daily-challenge">Explore all 4 locations</span></p>
+                <p>Daily Challenge: <span id="daily-challenge-text">Explore all locations</span> (<span id="daily-challenge-progress">0/0</span>)</p>
             </div>
 
             <div class="locations">


### PR DESCRIPTION
## Summary
- support daily challenges that change every day
- track progress for exploring unlocked locations, building, upgrading, or gathering resources
- display new challenge text and progress in the UI

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f1efcbe848320b84c5b51d82b42d9