### PR TITLE
Remove lucky charm repair and auto-use magic scroll

### DIFF
--- a/app.js
+++ b/app.js
@@ -461,31 +461,17 @@ if (buildWorkshopBtn) {
 
 // Crafting
 const craftBtn = document.getElementById('craft-lucky-charm');
-const repairCharmBtn = document.getElementById('repair-lucky-charm');
 const craftScrollBtn = document.getElementById('craft-magic-scroll');
-const useScrollBtn = document.getElementById('use-magic-scroll');
 if (craftBtn) {
     craftBtn.addEventListener('click', () => {
         console.log('Craft lucky charm clicked');
         craftLuckyCharm();
     });
 }
-if (repairCharmBtn) {
-    repairCharmBtn.addEventListener('click', () => {
-        console.log('Repair lucky charm clicked');
-        repairLuckyCharm();
-    });
-}
 if (craftScrollBtn) {
     craftScrollBtn.addEventListener('click', () => {
         console.log('Craft magic scroll clicked');
         craftMagicScroll();
-    });
-}
-if (useScrollBtn) {
-    useScrollBtn.addEventListener('click', () => {
-        console.log('Use magic scroll clicked');
-        useMagicScroll();
     });
 }
 
@@ -827,34 +813,18 @@ saveGame();
 
 }
 
-function repairLuckyCharm() {
-if (gameState.items.luckyCharm >= LUCKY_CHARM_MAX_USES) return;
-if (gameState.resources.tools < 1) return;
-gameState.resources.tools -= 1;
-gameState.items.luckyCharm = LUCKY_CHARM_MAX_USES;
-addEventLog('🔧 Repaired Lucky Charm to full uses.', 'success');
-updateUI();
-saveGame();
-}
 
 function craftMagicScroll() {
-const cost = { wood: 2, gems: 1 };
-if (!canAfford(cost)) return;
-spendResources(cost);
-gameState.items.magicScroll++;
-addEventLog('📜 Crafted a Magic Scroll!', 'success');
-gainXP(15);
-updateUI();
-saveGame();
-}
-
-function useMagicScroll() {
-if (gameState.items.magicScroll <= 0) return;
-gameState.items.magicScroll--;
-gainXP(20);
-addEventLog('✨ Used a Magic Scroll for bonus XP!', 'success');
-updateUI();
-saveGame();
+    const cost = { wood: 2, gems: 1 };
+    if (!canAfford(cost)) return;
+    spendResources(cost);
+    addEventLog('📜 Crafted a Magic Scroll!', 'success');
+    gainXP(15);
+    // Automatically gain the scroll's XP when crafted
+    gainXP(20);
+    addEventLog('✨ Magic Scroll activated for bonus XP!', 'success');
+    updateUI();
+    saveGame();
 }
 
 // Helper functions
@@ -1128,12 +1098,10 @@ updateBuildingsUI();
 // Items
 document.getElementById('lucky-charm-count').textContent = gameState.items.luckyCharm;
 document.getElementById('craft-lucky-charm').disabled = !canAfford({ wood: 3, stone: 2 });
-document.getElementById('repair-lucky-charm').disabled =
-    gameState.items.luckyCharm >= LUCKY_CHARM_MAX_USES || gameState.resources.tools < 1;
+
 
 document.getElementById('magic-scroll-count').textContent = gameState.items.magicScroll;
 document.getElementById('craft-magic-scroll').disabled = !canAfford({ wood: 2, gems: 1 });
-document.getElementById('use-magic-scroll').disabled = gameState.items.magicScroll <= 0;
 
 }
 

--- a/index.html
+++ b/index.html
@@ -183,20 +183,15 @@
                         <button class="craft-btn" id="craft-lucky-charm">
                             <span class="craft-cost">3 🪵 2 🗿</span>
                         </button>
-                        <button class="craft-btn" id="repair-lucky-charm">
-                            <span class="craft-cost">1 🔧</span>
-                        </button>
+                        <!-- Repair option removed -->
                     </div>
                     <div class="craft-item">
                         <span class="craft-icon">📜</span>
                         <span class="craft-name">Magic Scroll</span>
                         <span class="craft-owned" id="magic-scroll-count">0</span>
-                        <div class="craft-desc">Use to gain 20 XP instantly.</div>
+                        <div class="craft-desc">Craft to gain 20 XP instantly.</div>
                         <button class="craft-btn" id="craft-magic-scroll">
                             <span class="craft-cost">2 🪵 1 💎</span>
-                        </button>
-                        <button class="craft-btn" id="use-magic-scroll">
-                            Use
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove the Lucky Charm repair button and code
- auto-activate Magic Scroll XP when crafted
- drop unused event listeners and UI updates

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685f2c0ef72c83209cf84652d01590be