### PR TITLE
Introduce ruler traits with legacy effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,11 @@
                     <span class="stat-label">XP:</span>
                     <span id="xp">0</span>/<span id="xp-next">100</span>
                 </div>
+                <div class="stat" id="ruler-stat">
+                    <span class="stat-label">Ruler:</span>
+                    <span id="ruler-name">-</span> (<span id="ruler-age">0</span>)
+                    <span id="ruler-traits"></span>
+                </div>
             </div>
             <div class="season">
                 <span id="season">🌸 Spring</span>
@@ -46,7 +51,7 @@
         <section class="exploration" id="exploration">
             <h2>Exploration</h2>
             <div class="exploration-info">
-                <p>Explorations remaining today: <span id="explorations-left">5</span>/5</p>
+                <p>Explorations remaining today: <span id="explorations-left">5</span>/<span id="explorations-max">5</span></p>
                 <p>Daily Challenge: <span id="daily-challenge-text">Explore all locations</span> (<span id="daily-challenge-progress">0/0</span>)</p>
             </div>
 


### PR DESCRIPTION
## Summary
- add a legacy object to track past ruler traits
- implement helper functions for trait bonuses
- adjust building costs and exploration limits based on traits
- show ruler traits in the header and track maximum explorations
- award supplies for wealthy rulers and store trait legacy on succession

## Testing
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_68600d71ff0c8320a8c8630d5f003fc0