### PR TITLE
Implement legacy trait bonuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
                 <div class="stat" id="ruler-stat">
                     <span class="stat-label">Ruler:</span>
                     <span id="ruler-name">-</span> (<span id="ruler-age">0</span>)
+                    <div id="ruler-traits" class="ruler-traits"></div>
                 </div>
             </div>
             <div class="season">
@@ -50,7 +51,7 @@
         <section class="exploration" id="exploration">
             <h2>Exploration</h2>
             <div class="exploration-info">
-                <p>Explorations remaining today: <span id="explorations-left">5</span>/5</p>
+                <p>Explorations remaining today: <span id="explorations-left">5</span>/<span id="exploration-max">5</span></p>
                 <p>Daily Challenge: <span id="daily-challenge-text">Explore all locations</span> (<span id="daily-challenge-progress">0/0</span>)</p>
             </div>
 

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,11 @@ font-size: 0.8rem;
 opacity: 0.8;
 }
 
+#ruler-traits {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
 .season {
 font-size: 1.1rem;
 font-weight: bold;


### PR DESCRIPTION
## Summary
- track past ruler traits in `legacy`
- add trait helper functions for build costs and exploration limits
- announce new ruler traits and give wealthy resource bonus
- accumulate ruler traits into legacy when a ruler dies
- show ruler traits and exploration max in the UI

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68604b132a048320a7277ac07d68e352