### PR TITLE
Implement food shortage roll penalty

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -5,13 +5,14 @@ export const gameState = {
     level: 1,
     xp: 0,
     xpToNext: 100,
+    rollPenalty: 0,
     season: 'spring',
     explorationsLeft: CONSTANTS.BASE_EXPLORATIONS,
     resources: {
         wood: 0,
         stone: 0,
         metal: 0,
-        food: 0,
+        food: 10,
         tools: 0,
         gems: 0
     },


### PR DESCRIPTION
## Summary
- add `rollPenalty` to track dice roll penalties
- increase starting food to 10
- apply penalty when daily food demand isn't met
- display roll penalty in dice modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686081146a2083209c3fc620b4572b76