### PR TITLE
Improve UI usability and accessibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -423,6 +423,7 @@ if (craftScrollBtn) {
 // Event log controls
 const clearLogBtn = document.getElementById('clear-log-btn');
 const textSizeSelect = document.getElementById('text-size-select');
+const logSearch = document.getElementById('log-search');
 
 if (clearLogBtn) {
     clearLogBtn.addEventListener('click', () => {
@@ -435,14 +436,31 @@ if (textSizeSelect) {
     textSizeSelect.addEventListener('change', changeTextSize);
 }
 
+if (logSearch) {
+    logSearch.addEventListener('input', updateEventLogUI);
+}
+
 // Modal controls
 const closeModalBtn = document.getElementById('close-modal-btn');
+const modalCloseX = document.querySelector('.modal-close-btn');
 if (closeModalBtn) {
     closeModalBtn.addEventListener('click', () => {
         console.log('Close modal clicked');
         closeModal();
     });
 }
+if (modalCloseX) {
+    modalCloseX.addEventListener('click', () => closeModal());
+}
+
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+        const modal = document.getElementById('dice-modal');
+        if (modal && modal.classList.contains('show')) {
+            closeModal();
+        }
+    }
+});
 
 console.log('Event listeners setup complete');
 
@@ -1516,6 +1534,8 @@ function createConstructionElement(type) {
 
 function updateEventLogUI() {
 const logContent = document.getElementById('event-log-content');
+const search = document.getElementById('log-search');
+const term = search ? search.value.toLowerCase() : '';
 logContent.innerHTML = '';
 
 gameState.eventLog.forEach(entry => {
@@ -1525,7 +1545,9 @@ gameState.eventLog.forEach(entry => {
         <div><strong>Month ${entry.month}</strong> - ${entry.timestamp}</div>
         <div>${entry.message}</div>
     `;
-    logContent.appendChild(div);
+    if (!term || div.textContent.toLowerCase().includes(term)) {
+        logContent.appendChild(div);
+    }
 });
 
 }
@@ -1535,7 +1557,8 @@ function setupResourceBar() {
     if (!bar) return;
     bar.innerHTML = Object.keys(gameState.resources).map(r => {
         const icon = getResourceIcon(r);
-        return `<div class="resource"><span class="resource-icon">${icon}</span><span class="resource-amount" id="bar-${r}">${gameState.resources[r]}</span><span class="resource-production" id="bar-prod-${r}"></span></div>`;
+        const name = r.charAt(0).toUpperCase() + r.slice(1);
+        return `<div class="resource" title="${name}"><span class="resource-icon">${icon}</span><span class="resource-amount" id="bar-${r}">${gameState.resources[r]}</span><span class="resource-production" id="bar-prod-${r}"></span></div>`;
     }).join('');
 }
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
                 <div class="stat">
                     <span class="stat-label">XP:</span>
                     <span id="xp">0</span>/<span id="xp-next">100</span>
+                    <progress id="xp-progress" value="0" max="100" class="xp-progress" aria-label="Experience progress"></progress>
                 </div>
                 <div class="stat">
                     <span class="stat-label">Morale:</span>
@@ -43,10 +44,10 @@
             </div>
             <div id="resource-bar" class="resource-bar"></div>
             <nav class="quick-nav">
-                <a href="#exploration">Explore</a>
-                <a href="#event-log">Events</a>
-                <a href="#settlement">Settlement</a>
-                <a href="#month-section">Next Month</a>
+                <a href="#exploration" aria-label="Jump to exploration">Explore</a>
+                <a href="#event-log" aria-label="Jump to event log">Events</a>
+                <a href="#settlement" aria-label="Jump to settlement">Settlement</a>
+                <a href="#month-section" aria-label="Jump to next month controls">Next Month</a>
             </nav>
             <!-- Save/Load temporarily disabled -->
         </header>
@@ -61,7 +62,7 @@
             </div>
 
             <div class="locations">
-                <button class="location-btn" data-location="forest">
+                <button class="location-btn" data-location="forest" aria-label="Explore Deep Forest">
                     <span class="location-icon">🌲</span>
                     <span class="location-info">
                         <span class="location-name">Deep Forest</span>
@@ -70,7 +71,7 @@
                         <span class="location-level">Unlocks at level 1</span>
                     </span>
                 </button>
-                <button class="location-btn" data-location="quarry">
+                <button class="location-btn" data-location="quarry" aria-label="Explore Stone Quarry">
                     <span class="location-icon">⛰️</span>
                     <span class="location-info">
                         <span class="location-name">Stone Quarry</span>
@@ -79,7 +80,7 @@
                         <span class="location-level">Unlocks at level 1</span>
                     </span>
                 </button>
-                <button class="location-btn" data-location="plains">
+                <button class="location-btn" data-location="plains" aria-label="Explore Fertile Plains">
                     <span class="location-icon">🌾</span>
                     <span class="location-info">
                         <span class="location-name">Fertile Plains</span>
@@ -88,7 +89,7 @@
                         <span class="location-level">Unlocks at level 1</span>
                     </span>
                 </button>
-                <button class="location-btn" data-location="ruins">
+                <button class="location-btn" data-location="ruins" aria-label="Explore Ancient Ruins">
                     <span class="location-icon">🏛️</span>
                     <span class="location-info">
                         <span class="location-name">Ancient Ruins</span>
@@ -97,7 +98,7 @@
                         <span class="location-level">Unlocks at level 2</span>
                     </span>
                 </button>
-                <button class="location-btn" data-location="swamp">
+                <button class="location-btn" data-location="swamp" aria-label="Explore Misty Swamp">
                     <span class="location-icon">🐸</span>
                     <span class="location-info">
                         <span class="location-name">Misty Swamp</span>
@@ -106,7 +107,7 @@
                         <span class="location-level">Unlocks at level 2</span>
                     </span>
                 </button>
-                <button class="location-btn" data-location="mountains">
+                <button class="location-btn" data-location="mountains" aria-label="Explore High Mountains">
                     <span class="location-icon">🏔️</span>
                     <span class="location-info">
                         <span class="location-name">High Mountains</span>
@@ -115,7 +116,7 @@
                         <span class="location-level">Unlocks at level 3</span>
                     </span>
                 </button>
-                <button class="location-btn" data-location="cavern">
+                <button class="location-btn" data-location="cavern" aria-label="Explore Crystal Cavern">
                     <span class="location-icon">🕳️</span>
                     <span class="location-info">
                         <span class="location-name">Crystal Cavern</span>
@@ -124,7 +125,7 @@
                         <span class="location-level">Unlocks at level 4</span>
                     </span>
                 </button>
-                <button class="location-btn" data-location="lake">
+                <button class="location-btn" data-location="lake" aria-label="Explore Serene Lake">
                     <span class="location-icon">🌊</span>
                     <span class="location-info">
                         <span class="location-name">Serene Lake</span>
@@ -141,7 +142,8 @@
         <section class="event-log" id="event-log">
             <h2>Event Log</h2>
             <div class="log-controls">
-                <button id="clear-log-btn">Clear Log</button>
+                <button id="clear-log-btn" aria-label="Clear event log">Clear Log</button>
+                <input type="text" id="log-search" placeholder="Search log..." aria-label="Search event log">
                 <select id="text-size-select">
                     <option value="small">Small Text</option>
                     <option value="medium" selected>Medium Text</option>
@@ -161,7 +163,7 @@
                     <span class="settlement-icon">🏠</span>
                     <div class="settlement-info">
                         <div class="settlement-name">Home: <span id="home-level">Camp</span></div>
-                        <button class="upgrade-btn" id="home-upgrade-btn">
+                        <button class="upgrade-btn" id="home-upgrade-btn" aria-label="Upgrade home">
                             <span class="upgrade-text">Upgrade to House</span>
                             <span class="upgrade-cost">5 🪵</span>
                         </button>
@@ -172,7 +174,7 @@
                     <span class="settlement-icon">🛡️</span>
                     <div class="settlement-info">
                         <div class="settlement-name">Walls: <span id="walls-level">None</span></div>
-                        <button class="upgrade-btn" id="walls-upgrade-btn">
+                        <button class="upgrade-btn" id="walls-upgrade-btn" aria-label="Upgrade walls">
                             <span class="upgrade-text">Build Earthen Walls</span>
                             <span class="upgrade-cost">5 🪵</span>
                         </button>
@@ -187,57 +189,57 @@
             </div>
 
             <div class="buildings">
-                <div class="building-section">
-                    <h3>Farms (Camp) (<span id="farm-count">0</span>/<span id="farm-max">2</span>)</h3>
+                <details class="building-section" open>
+                    <summary>Farms (Camp) (<span id="farm-count">0</span>/<span id="farm-max">2</span>)</summary>
                     <div id="farms-container"></div>
-                    <button class="build-btn" id="build-farm-btn">
+                    <button class="build-btn" id="build-farm-btn" aria-label="Build Farm">
                         <span class="build-text">Build Farm</span>
                         <span class="build-cost">1 🪵 1 🗿</span>
                     </button>
-                </div>
+                </details>
 
-                <div class="building-section">
-                    <h3>Forester Huts (Camp) (<span id="forester-count">0</span>/<span id="forester-max">2</span>)</h3>
+                <details class="building-section" open>
+                    <summary>Forester Huts (Camp) (<span id="forester-count">0</span>/<span id="forester-max">2</span>)</summary>
                     <div id="foresters-container"></div>
-                    <button class="build-btn" id="build-forester-btn">
+                    <button class="build-btn" id="build-forester-btn" aria-label="Build Forester Hut">
                         <span class="build-text">Build Forester Hut</span>
                         <span class="build-cost">2 🪵 1 🗿</span>
                     </button>
-                </div>
+                </details>
 
-                <div class="building-section">
-                    <h3>Quarries (Camp) (<span id="quarry-count">0</span>/<span id="quarry-max">2</span>)</h3>
+                <details class="building-section" open>
+                    <summary>Quarries (Camp) (<span id="quarry-count">0</span>/<span id="quarry-max">2</span>)</summary>
                     <div id="quarries-container"></div>
-                    <button class="build-btn" id="build-quarry-btn">
+                    <button class="build-btn" id="build-quarry-btn" aria-label="Build Quarry">
                         <span class="build-text">Build Quarry</span>
                         <span class="build-cost">1 🪵 2 🗿</span>
                     </button>
-                </div>
-                <div class="building-section">
-                    <h3>Mines (House) (<span id="mine-count">0</span>/<span id="mine-max">2</span>)</h3>
+                </details>
+                <details class="building-section" open>
+                    <summary>Mines (House) (<span id="mine-count">0</span>/<span id="mine-max">2</span>)</summary>
                     <div id="mines-container"></div>
-                    <button class="build-btn" id="build-mine-btn">
+                    <button class="build-btn" id="build-mine-btn" aria-label="Build Mine">
                         <span class="build-text">Build Mine</span>
                         <span class="build-cost">2 🪵 2 🗿</span>
                     </button>
-                </div>
+                </details>
 
-                <div class="building-section">
-                    <h3>Gem Mines (Fortress) (<span id="gemMine-count">0</span>/<span id="gemMine-max">2</span>)</h3>
+                <details class="building-section" open>
+                    <summary>Gem Mines (Fortress) (<span id="gemMine-count">0</span>/<span id="gemMine-max">2</span>)</summary>
                     <div id="gemMines-container"></div>
-                    <button class="build-btn" id="build-gemMine-btn">
+                    <button class="build-btn" id="build-gemMine-btn" aria-label="Build Gem Mine">
                         <span class="build-text">Build Gem Mine</span>
                         <span class="build-cost">2 🪵 2 🗿 1 ⚔️</span>
                     </button>
-                </div>
-                <div class="building-section">
-                    <h3>Workshops (Hall) (<span id="workshop-count">0</span>/<span id="workshop-max">2</span>)</h3>
+                </details>
+                <details class="building-section" open>
+                    <summary>Workshops (Hall) (<span id="workshop-count">0</span>/<span id="workshop-max">2</span>)</summary>
                     <div id="workshops-container"></div>
-                    <button class="build-btn" id="build-workshop-btn">
+                    <button class="build-btn" id="build-workshop-btn" aria-label="Build Workshop">
                         <span class="build-text">Build Workshop</span>
                         <span class="build-cost">2 🪵 1 🗿</span>
                     </button>
-                </div>
+                </details>
             </div>
 
             <div class="crafting">
@@ -248,7 +250,7 @@
                         <span class="craft-name">Lucky Charm</span>
                         <span class="craft-owned" id="lucky-charm-count">0</span>
                         <div class="craft-desc">Adds +2 to your next 3 rolls.</div>
-                        <button class="craft-btn" id="craft-lucky-charm">
+                        <button class="craft-btn" id="craft-lucky-charm" aria-label="Craft Lucky Charm">
                             <span class="craft-cost">3 🪵 2 🗿</span>
                         </button>
                         <!-- Repair option removed -->
@@ -258,7 +260,7 @@
                         <span class="craft-name">Magic Scroll</span>
                         <span class="craft-owned" id="magic-scroll-count">0</span>
                         <div class="craft-desc">Craft to gain 20 XP instantly.</div>
-                        <button class="craft-btn" id="craft-magic-scroll">
+                        <button class="craft-btn" id="craft-magic-scroll" aria-label="Craft Magic Scroll">
                             <span class="craft-cost">2 🪵 1 💎</span>
                         </button>
                     </div>
@@ -267,7 +269,7 @@
         </section>
 
         <section class="sleep-section" id="month-section">
-            <button id="next-month-btn" class="sleep-btn" disabled>
+            <button id="next-month-btn" class="sleep-btn" disabled aria-label="Advance to next month">
                 <span class="sleep-icon">😴</span>
                 Go To Next Month
             </button>
@@ -278,6 +280,7 @@
     <!-- Dice Roll Modal -->
     <div id="dice-modal" class="modal">
         <div class="modal-content">
+            <button class="modal-close-btn" aria-label="Close">&times;</button>
             <div class="dice-container">
                 <div class="dice" id="dice">
                     <div class="dice-face">?</div>

--- a/styles.css
+++ b/styles.css
@@ -52,6 +52,12 @@ flex-direction: column;
 align-items: center;
 }
 
+.xp-progress {
+  width: 100%;
+  height: 0.5rem;
+  margin-top: 0.25rem;
+}
+
 .stat-label {
 font-size: 0.8rem;
 opacity: 0.8;
@@ -97,6 +103,9 @@ font-weight: bold;
   justify-content: space-around;
   background: #34495e;
   padding: 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 900;
 }
 
 .quick-nav a {
@@ -322,11 +331,21 @@ margin-bottom: 1.5rem;
 }
 
 .building-section {
-background: white;
-border-radius: 8px;
-padding: 1rem;
-margin-bottom: 1rem;
-box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  background: white;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.building-section > summary {
+  font-weight: bold;
+  cursor: pointer;
+  list-style: none;
+}
+
+.building-section[open] {
+  padding-bottom: 1rem;
 }
 
 .building-item {
@@ -566,6 +585,16 @@ font-size: 1rem;
 font-weight: bold;
 cursor: pointer;
 transition: all 0.3s ease;
+}
+
+.modal-close-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
 }
 
 .modal-btn:hover {

--- a/uiManager.js
+++ b/uiManager.js
@@ -31,6 +31,11 @@ export class UIManager {
   updateXP(xp, next) {
     if (this.elements.xp) this.elements.xp.textContent = xp;
     if (this.elements.xpNext) this.elements.xpNext.textContent = next;
+    const prog = document.getElementById('xp-progress');
+    if (prog) {
+      prog.max = next;
+      prog.value = xp;
+    }
   }
 
   updateSeason(text) {


### PR DESCRIPTION
## Summary
- add XP progress bar
- make quick navigation sticky and accessible
- allow searching/filtering of event log
- convert building sections to collapsible details
- add tooltips and ARIA labels
- add close button and keyboard controls for dice modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862bbf889f08320a2e54b1304d1d2c7