### PR TITLE
Improve mobile UI with responsive tweaks

### DIFF
--- a/app.js
+++ b/app.js
@@ -312,14 +312,36 @@ locationBtns.forEach((btn, index) => {
 
 // Next month button
 const nextMonthBtn = document.getElementById('next-month-btn');
-    if (nextMonthBtn) {
-        nextMonthBtn.addEventListener('click', (e) => {
-            console.log('Next month button clicked');
-            advanceMonth();
-        });
+if (nextMonthBtn) {
+    nextMonthBtn.addEventListener('click', () => {
+        console.log('Next month button clicked');
+        advanceMonth();
+    });
+} else {
+    console.error('Next month button not found!');
+}
+
+// Floating next month button
+const fabNext = document.getElementById('fab-next-month');
+if (fabNext) {
+    fabNext.addEventListener('click', () => {
+        console.log('FAB next month clicked');
+        advanceMonth();
+    });
+}
+
+// Auto hide header on scroll
+let lastScroll = window.scrollY;
+window.addEventListener('scroll', () => {
+    const header = document.querySelector('header');
+    if (!header) return;
+    if (window.scrollY > lastScroll && window.scrollY > 50) {
+        header.classList.add('hide-header');
     } else {
-        console.error('Next month button not found!');
+        header.classList.remove('hide-header');
     }
+    lastScroll = window.scrollY;
+});
 
     // Save and load buttons
     const saveBtn = document.getElementById('save-btn');

--- a/index.html
+++ b/index.html
@@ -44,10 +44,18 @@
             </div>
             <div id="resource-bar" class="resource-bar"></div>
             <nav class="quick-nav">
-                <a href="#exploration" aria-label="Jump to exploration">Explore</a>
-                <a href="#event-log" aria-label="Jump to event log">Events</a>
-                <a href="#settlement" aria-label="Jump to settlement">Settlement</a>
-                <a href="#month-section" aria-label="Jump to next month controls">Next Month</a>
+                <a href="#exploration" aria-label="Jump to exploration">
+                    <span class="icon">🗺️</span><span class="label">Explore</span>
+                </a>
+                <a href="#event-log" aria-label="Jump to event log">
+                    <span class="icon">📜</span><span class="label">Events</span>
+                </a>
+                <a href="#settlement" aria-label="Jump to settlement">
+                    <span class="icon">🏠</span><span class="label">Settlement</span>
+                </a>
+                <a href="#month-section" class="top-next-month" aria-label="Jump to next month controls">
+                    <span class="icon">⏭️</span><span class="label">Next Month</span>
+                </a>
             </nav>
             <!-- Save/Load temporarily disabled -->
         </header>
@@ -297,6 +305,7 @@
             <button id="close-modal-btn" class="modal-btn">Continue</button>
         </div>
     </div>
+    <button id="fab-next-month" class="fab" aria-label="Advance to next month">⏭️</button>
 </div>
 
 <!-- Load the main script as an ES module -->

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,11 @@ text-align: center;
 position: sticky;
 top: 0;
 z-index: 1000;
+transition: transform 0.3s ease;
+}
+
+header.hide-header {
+  transform: translateY(-100%);
 }
 
 header h1 {
@@ -40,10 +45,12 @@ margin-bottom: 0.5rem;
 }
 
 .stats {
-display: flex;
-justify-content: space-between;
-margin-bottom: 0.5rem;
-font-size: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
 }
 
 .stat {
@@ -112,6 +119,16 @@ font-weight: bold;
   color: white;
   text-decoration: none;
   font-weight: bold;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.quick-nav .icon {
+  display: none;
+}
+.quick-nav .label {
+  display: inline;
 }
 
 .save-load {
@@ -295,6 +312,24 @@ cursor: not-allowed;
 .sleep-icon {
 margin-right: 0.5rem;
 font-size: 1.3rem;
+}
+
+.fab {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #8e44ad 0%, #9b59b6 100%);
+  color: white;
+  border: none;
+  font-size: 1.5rem;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+  z-index: 1000;
 }
 
 /* Settlement */
@@ -640,14 +675,42 @@ main {
 }
 
 
-.location-btn {
-    padding: 0.8rem;
-}
 
-.location-icon {
+  .stats {
+    justify-content: center;
+  }
+
+  .quick-nav .label {
+    display: none;
+  }
+  .quick-nav .icon {
+    display: inline;
+    font-size: 1.2rem;
+  }
+  .quick-nav .top-next-month {
+    display: none;
+  }
+
+  .locations {
+    display: flex;
+    overflow-x: auto;
+    gap: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  .location-btn {
+    padding: 0.8rem;
+    min-width: 160px;
+    flex: 0 0 auto;
+  }
+
+  .location-icon {
     font-size: 1.5rem;
     margin-right: 0.8rem;
-}
+  }
+
+  .fab {
+    display: flex;
+  }
 
 }
 


### PR DESCRIPTION
## Summary
- adjust header and navigation for small screens
- add floating button for advancing the month
- allow horizontal scrolling of locations on mobile
- auto-hide the header while scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862fb087184832094f068d546beea35