### PR TITLE
Add new buildings and horizontal scroll

### DIFF
--- a/data/buildings.js
+++ b/data/buildings.js
@@ -78,5 +78,59 @@ export const BUILDING_TYPES = {
       advanced: { name: 'Advanced', upgradeTo: 'master', cost: { stone: 6, metal: 4 }, production: 3 },
       master: { name: 'Master', upgradeTo: null, cost: null, production: 5 }
     }
+  },
+  sawmill: {
+    name: 'Sawmill',
+    icon: '🪚',
+    buildCost: { wood: 3, stone: 2 },
+    requiredLevel: 2,
+    requiredHome: 'house',
+    levels: {
+      basic: { name: 'Basic', upgradeTo: 'improved', cost: { wood: 2 }, production: 1 },
+      improved: { name: 'Improved', upgradeTo: 'advanced', cost: { wood: 5, stone: 2 }, production: 2 },
+      advanced: { name: 'Advanced', upgradeTo: 'master', cost: { wood: 10, stone: 5, metal: 2 }, production: 3 },
+      master: { name: 'Master', upgradeTo: null, cost: null, production: 5 }
+    }
+  },
+  granary: {
+    name: 'Granary',
+    icon: '🍞',
+    buildCost: { wood: 2, stone: 2 },
+    requiredLevel: 2,
+    requiredHome: 'house',
+    levels: {
+      basic: { name: 'Basic', upgradeTo: 'improved', cost: { wood: 2 }, production: 1 },
+      improved: { name: 'Improved', upgradeTo: 'advanced', cost: { wood: 5, stone: 2 }, production: 2 },
+      advanced: { name: 'Advanced', upgradeTo: 'master', cost: { wood: 10, stone: 5, metal: 2 }, production: 3 },
+      master: { name: 'Master', upgradeTo: null, cost: null, production: 5 }
+    }
+  },
+  smelter: {
+    name: 'Smelter',
+    icon: '🔥',
+    buildCost: { wood: 2, stone: 3, metal: 1 },
+    requiredLevel: 3,
+    requiredHome: 'hall',
+    requiredTech: 'metallurgy',
+    levels: {
+      basic: { name: 'Basic', upgradeTo: 'improved', cost: { wood: 3 }, production: 1 },
+      improved: { name: 'Improved', upgradeTo: 'advanced', cost: { wood: 6, stone: 3 }, production: 2 },
+      advanced: { name: 'Advanced', upgradeTo: 'master', cost: { wood: 12, stone: 6, metal: 4 }, production: 3 },
+      master: { name: 'Master', upgradeTo: null, cost: null, production: 5 }
+    }
+  },
+  barracks: {
+    name: 'Barracks',
+    icon: '🏹',
+    buildCost: { wood: 3, stone: 3, metal: 2 },
+    requiredLevel: 4,
+    requiredHome: 'fortress',
+    requiredTech: 'fortifications',
+    levels: {
+      basic: { name: 'Basic', upgradeTo: 'improved', cost: { wood: 3 }, production: 1 },
+      improved: { name: 'Improved', upgradeTo: 'advanced', cost: { wood: 6, stone: 3 }, production: 2 },
+      advanced: { name: 'Advanced', upgradeTo: 'master', cost: { wood: 12, stone: 6, metal: 4 }, production: 3 },
+      master: { name: 'Master', upgradeTo: null, cost: null, production: 5 }
+    }
   }
 };

--- a/gameState.js
+++ b/gameState.js
@@ -26,6 +26,10 @@ export const gameState = {
         workshops: [],
         foresters: [],
         gemMines: [],
+        sawmills: [],
+        granaries: [],
+        smelters: [],
+        barracks: [],
         pendingHome: null,
         constructionQueue: []
     },

--- a/index.html
+++ b/index.html
@@ -248,6 +248,38 @@
                         <span class="build-cost">2 🪵 1 🗿</span>
                     </button>
                 </details>
+                <details class="building-section" open>
+                    <summary>Sawmills (House) (<span id="sawmill-count">0</span>/<span id="sawmill-max">1</span>)</summary>
+                    <div id="sawmills-container"></div>
+                    <button class="build-btn" id="build-sawmill-btn" aria-label="Build Sawmill">
+                        <span class="build-text">Build Sawmill</span>
+                        <span class="build-cost">3 🪵 2 🗿</span>
+                    </button>
+                </details>
+                <details class="building-section" open>
+                    <summary>Granaries (House) (<span id="granary-count">0</span>/<span id="granary-max">1</span>)</summary>
+                    <div id="granaries-container"></div>
+                    <button class="build-btn" id="build-granary-btn" aria-label="Build Granary">
+                        <span class="build-text">Build Granary</span>
+                        <span class="build-cost">2 🪵 2 🗿</span>
+                    </button>
+                </details>
+                <details class="building-section" open>
+                    <summary>Smelters (Hall) (<span id="smelter-count">0</span>/<span id="smelter-max">1</span>)</summary>
+                    <div id="smelters-container"></div>
+                    <button class="build-btn" id="build-smelter-btn" aria-label="Build Smelter">
+                        <span class="build-text">Build Smelter</span>
+                        <span class="build-cost">2 🪵 3 🗿 1 ⚔️</span>
+                    </button>
+                </details>
+                <details class="building-section" open>
+                    <summary>Barracks (Fortress) (<span id="barracks-count">0</span>/<span id="barracks-max">1</span>)</summary>
+                    <div id="barracks-container"></div>
+                    <button class="build-btn" id="build-barracks-btn" aria-label="Build Barracks">
+                        <span class="build-text">Build Barracks</span>
+                        <span class="build-cost">3 🪵 3 🗿 2 ⚔️</span>
+                    </button>
+                </details>
             </div>
 
             <div class="crafting">

--- a/styles.css
+++ b/styles.css
@@ -362,7 +362,10 @@ margin-bottom: 0.5rem;
 }
 
 .buildings {
-margin-bottom: 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
 }
 
 .building-section {
@@ -701,6 +704,18 @@ main {
     padding: 0.8rem;
     min-width: 160px;
     flex: 0 0 auto;
+  }
+
+  .buildings {
+    display: flex;
+    overflow-x: auto;
+    gap: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  .building-section {
+    min-width: 220px;
+    flex: 0 0 auto;
+    margin-bottom: 0;
   }
 
   .location-icon {


### PR DESCRIPTION
## Summary
- introduce four new buildings (Sawmill, Granary, Smelter, Barracks)
- support storing these new building types in game state
- update home building limits and helper function for plural rules
- show new building sections in UI
- compute monthly production from new buildings
- enable horizontal scrolling of buildings on small screens
- default building layout uses responsive grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862ff073304832093f0c1167c0147f5