### PR TITLE
Add scroll hint and building output info

### DIFF
--- a/app.js
+++ b/app.js
@@ -262,6 +262,7 @@ try {
     updateResearchUI();
     debouncedRefreshGameInterface();
 setupEventListeners();
+    initScrollIndicators();
 console.log('Game initialized successfully!');
 
     // Test that buttons exist
@@ -1337,6 +1338,7 @@ updateSettlementUI();
     updateEventLogUI();
     updateMonthlyChallengeUI();
     checkMonthlyChallengeCompletion();
+    updateScrollIndicators();
 
 }
 
@@ -1715,7 +1717,7 @@ function createBuildingElement(type, building) {
 
     const levelText = upgrading
         ? `Upgrading to ${buildingType.levels[building.pendingLevel].name}...`
-        : `${currentLevel.name} (${currentLevel.production} production)`;
+        : `${currentLevel.name} (${getProductionDescription(type, currentLevel)})`;
 
     div.innerHTML = `
         <div class="building-info">
@@ -1811,6 +1813,20 @@ tools: '🔧',
 gems: '💎'
 };
 return icons[resource] || resource;
+}
+
+function getProductionDescription(type, levelData) {
+    const bt = BUILDING_TYPES[type];
+    const parts = [];
+    if (bt.consumes && levelData[`${bt.consumes}Cost`]) {
+        parts.push(`-${levelData[`${bt.consumes}Cost`]} ${bt.consumes}`);
+    }
+    if (bt.produces) {
+        parts.push(`+${levelData.production} ${bt.produces}`);
+    } else {
+        parts.push(`${levelData.production} production`);
+    }
+    return parts.join(' \u2192 ');
 }
 
 function formatCost(cost) {
@@ -1947,6 +1963,24 @@ function loadGame(slot = 'default') {
     // Temporarily disable loading while save/load is suspended
     console.log('Load feature is currently disabled.');
     return;
+}
+
+function initScrollIndicators() {
+    const containers = document.querySelectorAll('.scroll-container');
+    const update = () => updateScrollIndicators(containers);
+    update();
+    containers.forEach(el => el.addEventListener('scroll', update));
+    window.addEventListener('resize', update);
+}
+
+function updateScrollIndicators(containers = document.querySelectorAll('.scroll-container')) {
+    containers.forEach(el => {
+        if (el.scrollWidth - el.clientWidth - el.scrollLeft > 1) {
+            el.classList.add('scrollable');
+        } else {
+            el.classList.remove('scrollable');
+        }
+    });
 }
 
 // Initialize when page loads. Only run initGame once

--- a/data/buildings.js
+++ b/data/buildings.js
@@ -3,6 +3,7 @@ export const BUILDING_TYPES = {
     name: 'Farm',
     icon: '🌾',
     buildCost: { wood: 1, stone: 1 },
+    produces: 'food',
     requiredLevel: 1,
     requiredHome: 'camp',
     levels: {
@@ -16,6 +17,7 @@ export const BUILDING_TYPES = {
     name: 'Quarry',
     icon: '⛏️',
     buildCost: { wood: 1, stone: 2 },
+    produces: 'stone',
     requiredLevel: 1,
     requiredHome: 'camp',
     levels: {
@@ -29,6 +31,7 @@ export const BUILDING_TYPES = {
     name: 'Mine',
     icon: '⚒️',
     buildCost: { wood: 2, stone: 2 },
+    produces: 'metal',
     requiredLevel: 2,
     requiredHome: 'house',
     levels: {
@@ -42,6 +45,8 @@ export const BUILDING_TYPES = {
     name: 'Workshop',
     icon: '🔧',
     buildCost: { wood: 2, stone: 1 },
+    produces: 'tools',
+    consumes: 'wood',
     requiredLevel: 3,
     requiredHome: 'hall',
     requiredTech: 'metallurgy',
@@ -56,6 +61,7 @@ export const BUILDING_TYPES = {
     name: 'Forester Hut',
     icon: '🌳',
     buildCost: { wood: 2, stone: 1 },
+    produces: 'wood',
     requiredLevel: 2,
     requiredHome: 'camp',
     levels: {
@@ -69,6 +75,7 @@ export const BUILDING_TYPES = {
     name: 'Gem Mine',
     icon: '💎',
     buildCost: { wood: 2, stone: 2, metal: 1 },
+    produces: 'gems',
     requiredLevel: 4,
     requiredHome: 'fortress',
     requiredTech: 'metallurgy',
@@ -83,6 +90,7 @@ export const BUILDING_TYPES = {
     name: 'Sawmill',
     icon: '🪚',
     buildCost: { wood: 3, stone: 2 },
+    produces: 'wood',
     requiredLevel: 2,
     requiredHome: 'house',
     levels: {
@@ -96,6 +104,7 @@ export const BUILDING_TYPES = {
     name: 'Granary',
     icon: '🍞',
     buildCost: { wood: 2, stone: 2 },
+    produces: 'food',
     requiredLevel: 2,
     requiredHome: 'house',
     levels: {
@@ -109,6 +118,7 @@ export const BUILDING_TYPES = {
     name: 'Smelter',
     icon: '🔥',
     buildCost: { wood: 2, stone: 3, metal: 1 },
+    produces: 'metal',
     requiredLevel: 3,
     requiredHome: 'hall',
     requiredTech: 'metallurgy',
@@ -123,6 +133,7 @@ export const BUILDING_TYPES = {
     name: 'Barracks',
     icon: '🏹',
     buildCost: { wood: 3, stone: 3, metal: 2 },
+    produces: 'tools',
     requiredLevel: 4,
     requiredHome: 'fortress',
     requiredTech: 'fortifications',

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
                 <p>Monthly Challenge: <span id="daily-challenge-text">Explore all locations</span> (<span id="daily-challenge-progress">0/0</span>)</p>
             </div>
 
-            <div class="locations">
+            <div class="locations scroll-container">
                 <button class="location-btn" data-location="forest" aria-label="Explore Deep Forest">
                     <span class="location-icon">🌲</span>
                     <span class="location-info">
@@ -196,7 +196,7 @@
                 </div>
             </div>
 
-            <div class="buildings">
+            <div class="buildings scroll-container">
                 <details class="building-section" open>
                     <summary>Farms (Camp) (<span id="farm-count">0</span>/<span id="farm-max">2</span>)</summary>
                     <div id="farms-container"></div>
@@ -284,7 +284,7 @@
 
             <div class="crafting">
                 <h3>Crafting</h3>
-                <div class="craft-items">
+                <div class="craft-items scroll-container">
                     <div class="craft-item">
                         <span class="craft-icon">🍀</span>
                         <span class="craft-name">Lucky Charm</span>

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,26 @@ padding: 0;
 margin: 0;
 }
 
+.scroll-container {
+  position: relative;
+}
+
+.scroll-container::after {
+  content: '➟';
+  position: absolute;
+  right: 0.3rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.2rem;
+  color: #aaa;
+  pointer-events: none;
+  display: none;
+}
+
+.scroll-container.scrollable::after {
+  display: block;
+}
+
 #app {
 max-width: 400px;
 margin: 0 auto;
@@ -462,16 +482,20 @@ box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
 
 .craft-items {
-display: grid;
-gap: 0.8rem;
+  display: flex;
+  overflow-x: auto;
+  gap: 0.8rem;
+  padding-bottom: 0.5rem;
 }
 
 .craft-item {
-display: flex;
-align-items: center;
-padding: 0.8rem;
-background: #f8f9fa;
-border-radius: 6px;
+  display: flex;
+  align-items: center;
+  padding: 0.8rem;
+  background: #f8f9fa;
+  border-radius: 6px;
+  flex: 0 0 auto;
+  min-width: 160px;
 }
 
 .craft-icon {


### PR DESCRIPTION
## Summary
- make location/building/crafting containers horizontally scrollable
- add arrow indicators that show when more items are offscreen
- describe each building's consumption and production

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686301be1f2c83209c6ffafd78f45ece