### PR TITLE
Add settlement dashboard with progress bars and happiness meter

### DIFF
--- a/app.js
+++ b/app.js
@@ -1433,6 +1433,8 @@ document.getElementById('craft-lucky-charm').disabled = !canAfford({ wood: 3, st
 document.getElementById('magic-scroll-count').textContent = gameState.items.magicScroll;
 document.getElementById('craft-magic-scroll').disabled = !canAfford({ wood: 2, gems: 1 });
 
+    updateSettlementDashboard();
+
 }
 
 function updateBuildingsUI() {
@@ -1761,14 +1763,66 @@ function createBuildingElement(type, building) {
 function createConstructionElement(type) {
     const buildingType = BUILDING_TYPES[type];
     const div = document.createElement('div');
-    div.className = 'building-item under-construction';
+    div.className = 'building-item under-construction construction-item';
     div.innerHTML = `
         <div class="building-info">
             <div class="building-name">${buildingType.icon} ${buildingType.name}</div>
             <div class="building-level">Building...</div>
+            <div class="progress-bar"><div class="progress"></div></div>
         </div>
     `;
     return div;
+}
+
+function updateSettlementDashboard() {
+    const overview = document.getElementById('building-overview');
+    if (overview) {
+        let html = '';
+        Object.keys(BUILDING_TYPES).forEach(t => {
+            const key = getBuildingKey(t);
+            const count = gameState.settlement[key].length;
+            if (count > 0) {
+                const icon = BUILDING_TYPES[t].icon;
+                html += `<span title="${BUILDING_TYPES[t].name}">${icon.repeat(count)}</span>`;
+            }
+        });
+        overview.innerHTML = html || '<em>No buildings yet</em>';
+    }
+
+    const happiness = document.getElementById('happiness-meter');
+    if (happiness) {
+        const val = gameState.morale;
+        let face = '😀';
+        if (val < 25) face = '😠';
+        else if (val < 50) face = '😟';
+        else if (val < 75) face = '🙂';
+        happiness.textContent = `${face} ${val}`;
+    }
+
+    const construction = document.getElementById('construction-progress');
+    if (construction) {
+        construction.innerHTML = '';
+        gameState.settlement.constructionQueue.forEach(b => {
+            const item = document.createElement('div');
+            item.className = 'construction-item';
+            const bt = BUILDING_TYPES[b.type];
+            item.innerHTML = `<span class="construction-label">${bt.icon} ${bt.name}</span><div class="progress-bar"><div class="progress"></div></div>`;
+            construction.appendChild(item);
+        });
+        if (gameState.settlement.constructionQueue.length === 0) {
+            construction.innerHTML = '<em>No construction</em>';
+        }
+    }
+
+    const stats = document.getElementById('settlement-stats');
+    if (stats) {
+        const totalBuildings = Object.keys(BUILDING_TYPES).reduce((sum, t) => sum + gameState.settlement[getBuildingKey(t)].length, 0);
+        stats.innerHTML = `
+            <div class="stat-item">Population: ${gameState.population}</div>
+            <div class="stat-item">Buildings: ${totalBuildings}</div>
+            <div class="stat-item">Morale: ${gameState.morale}</div>
+        `;
+    }
 }
 
 function updateEventLogUI() {

--- a/index.html
+++ b/index.html
@@ -181,6 +181,13 @@
         <!-- Settlement -->
         <section class="settlement" id="settlement">
             <h2>Your Settlement</h2>
+
+            <div class="settlement-dashboard">
+                <div id="building-overview" class="dashboard-section"></div>
+                <div id="happiness-meter" class="dashboard-section"></div>
+                <div id="construction-progress" class="dashboard-section"></div>
+                <div id="settlement-stats" class="dashboard-section"></div>
+            </div>
             
             <div class="settlement-overview">
                 <div class="settlement-item">

--- a/styles.css
+++ b/styles.css
@@ -836,3 +836,60 @@ padding-bottom: env(safe-area-inset-bottom);
 }
 /* Research */
 .research { background: white; border-radius: 8px; padding: 1rem; box-shadow: 0 2px 5px rgba(0,0,0,0.1); margin-top: 1rem; }
+
+/* Settlement dashboard */
+.settlement-dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.dashboard-section {
+  background: #f0f4f8;
+  border-radius: 6px;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+#building-overview span {
+  margin: 0 0.15rem;
+  font-size: 1.2rem;
+}
+
+#happiness-meter {
+  font-size: 1.5rem;
+}
+
+.construction-item {
+  margin-bottom: 0.4rem;
+}
+
+.progress-bar {
+  position: relative;
+  height: 6px;
+  background: #ccc;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-top: 0.25rem;
+}
+
+.progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  background: linear-gradient(90deg, #3498db, #8e44ad);
+  animation: progress-indef 1s linear infinite;
+}
+
+.stat-item {
+  font-size: 0.9rem;
+  margin-bottom: 0.2rem;
+}
+
+@keyframes progress-indef {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(100%); }
+}

--- a/uiManager.js
+++ b/uiManager.js
@@ -43,7 +43,13 @@ export class UIManager {
   }
 
   updateMorale(val) {
-    if (this.elements.morale) this.elements.morale.textContent = val;
+    if (this.elements.morale) {
+      let face = '😀';
+      if (val < 25) face = '😠';
+      else if (val < 50) face = '😟';
+      else if (val < 75) face = '🙂';
+      this.elements.morale.textContent = `${face} ${val}`;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add a settlement dashboard with building overview
- show construction progress and key stats
- display happiness with emoji faces
- style dashboard sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863101c48648320b3a9ed3fb5663b42