### PR TITLE
Improve header layout and visuals

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ import { gameState } from './gameState.js';
 import { LOCATIONS } from './data/locations.js';
 import { BUILDING_TYPES } from './data/buildings.js';
 import { TECHNOLOGIES } from './data/technologies.js';
-import { CONSTANTS } from './constants.js';
+import { CONSTANTS, RESOURCE_COLORS } from './constants.js';
 import { uiManager } from './uiManager.js';
 import { startResearch, progressResearch, getAvailableTechnologies, getResearchProgress } from './research.js';
 
@@ -1852,7 +1852,7 @@ function setupResourceBar() {
         const icon = getResourceIcon(r);
         const name = r.charAt(0).toUpperCase() + r.slice(1);
         const amount = gameState.resources[r];
-        const color = getResourceColor(amount);
+        const color = getResourceColor(r);
         return `
             <div class="resource" title="${name}">
                 <div class="resource-circle" id="circle-${r}" style="--progress:${Math.min(100, amount)};--color:${color}">
@@ -1878,7 +1878,7 @@ function updateResourceBar() {
         const circle = document.getElementById(`circle-${r}`);
         if (circle) {
             circle.style.setProperty('--progress', Math.min(100, amount));
-            circle.style.setProperty('--color', getResourceColor(amount));
+            circle.style.setProperty('--color', getResourceColor(r));
         }
         const prodEl = document.getElementById(`bar-prod-${r}`);
         if (prodEl) {
@@ -1915,10 +1915,8 @@ gems: '💎'
 return icons[resource] || resource;
 }
 
-function getResourceColor(amount) {
-    if (amount >= 20) return '#2ecc71';
-    if (amount >= 10) return '#f1c40f';
-    return '#e74c3c';
+function getResourceColor(resource) {
+    return RESOURCE_COLORS[resource] || '#3498db';
 }
 
 function animateCounter(el, from, to) {

--- a/constants.js
+++ b/constants.js
@@ -4,3 +4,12 @@ export const CONSTANTS = {
   LEVEL_XP_MULTIPLIER: 1.2,
   SEASON_CYCLE_MONTHS: 4
 };
+
+export const RESOURCE_COLORS = {
+  wood: '#27ae60',
+  stone: '#7f8c8d',
+  metal: '#95a5a6',
+  food: '#e67e22',
+  tools: '#3498db',
+  gems: '#9b59b6'
+};

--- a/index.html
+++ b/index.html
@@ -15,34 +15,31 @@
     <div id="app">
         <header>
             <h1>🛡️ Dice & Castle</h1>
-            <div class="stats">
-                <div class="stat">
-                    <span class="stat-label">Month:</span>
+            <div class="header-cards">
+                <div class="stat-card month-card">
+                    <span class="stat-label">Month</span>
                     <span id="month">1</span>
+                    <span id="season" class="season">🌸 Spring</span>
                 </div>
-                <div class="stat">
-                    <span class="stat-label">Level:</span>
-                    <span id="level">1</span>
-                </div>
-                <div class="stat">
-                    <span class="stat-label">XP:</span>
-                    <span id="xp">0</span>/<span id="xp-next">100</span>
+                <div class="stat-card xp-card">
+                    <div class="level-line">
+                        <span class="stat-label">Level</span>
+                        <span id="level">1</span>
+                    </div>
                     <progress id="xp-progress" value="0" max="100" class="xp-progress" aria-label="Experience progress"></progress>
+                    <div class="xp-amount"><span id="xp">0</span>/<span id="xp-next">100</span></div>
                 </div>
-                <div class="stat">
-                    <span class="stat-label">Morale:</span>
+                <div class="stat-card morale-card">
+                    <span class="stat-label">Morale</span>
                     <span id="morale">100</span>
                 </div>
-                <div class="stat" id="ruler-stat">
-                    <span class="stat-label">Ruler:</span>
+                <div class="stat-card ruler-card" id="ruler-stat">
+                    <span class="stat-label">Ruler</span>
                     <span id="ruler-name">-</span> (<span id="ruler-age">0</span>)
                     <div id="ruler-traits" class="ruler-traits"></div>
                 </div>
             </div>
-            <div class="season">
-                <span id="season">🌸 Spring</span>
-            </div>
-            <div id="resource-bar" class="resource-bar"></div>
+            <div id="resource-bar" class="resource-bar resource-cards"></div>
             <nav class="quick-nav">
                 <a href="#exploration" aria-label="Jump to exploration">
                     <span class="icon">🗺️</span><span class="label">Explore</span>

--- a/styles.css
+++ b/styles.css
@@ -45,14 +45,16 @@ box-shadow: 0 0 20px rgba(0,0,0,0.1);
 
 /* Header */
 header {
-background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
-color: white;
-padding: 1rem;
-text-align: center;
-position: sticky;
-top: 0;
-z-index: 1000;
-transition: transform 0.3s ease;
+  background: rgba(44, 62, 80, 0.6);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  transition: transform 0.3s ease;
 }
 
 header.hide-header {
@@ -64,25 +66,72 @@ font-size: 1.5rem;
 margin-bottom: 0.5rem;
 }
 
-.stats {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
+.header-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
   gap: 0.5rem;
   margin-bottom: 0.5rem;
   font-size: 0.9rem;
 }
 
-.stat {
-display: flex;
-flex-direction: column;
-align-items: center;
+.stat-card {
+  background: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border-radius: 10px;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.xp-card {
+  grid-column: span 2;
+}
+
+.level-line {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.xp-amount {
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
 }
 
 .xp-progress {
   width: 100%;
   height: 0.5rem;
   margin-top: 0.25rem;
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+}
+
+.xp-progress.shimmer::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent, rgba(255,255,255,0.6), transparent);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s linear infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.pulse {
+  animation: pulse 0.5s ease;
+}
+
+@keyframes pulse {
+  0%,100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
 }
 
 .stat-label {
@@ -102,20 +151,30 @@ font-weight: bold;
 
 .resource-bar {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   flex-wrap: wrap;
-  background: #ecf0f1;
+  gap: 0.5rem;
+  background: transparent;
   padding: 0.5rem;
   color: #2c3e50;
 }
 
 .resource-bar .resource {
-  background: none;
-  box-shadow: none;
+  background: rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  border-radius: 8px;
   padding: 0.25rem;
   display: flex;
   flex-direction: column;
   align-items: center;
+  border: 2px solid var(--color, #fff);
+  color: var(--color, #fff);
+  transition: transform 0.2s ease;
+}
+
+.resource-bar .resource:active {
+  transform: scale(0.97);
 }
 
 .resource-bar .resource-circle {
@@ -125,7 +184,7 @@ font-weight: bold;
   width: 50px;
   height: 50px;
   border-radius: 50%;
-  background: conic-gradient(var(--color) calc(var(--progress) * 1%), #ddd 0);
+  background: conic-gradient(var(--color) calc(var(--progress) * 1%), rgba(255,255,255,0.1) 0);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -140,9 +199,10 @@ font-weight: bold;
   left: 4px;
   right: 4px;
   bottom: 4px;
-  background: #ecf0f1;
+  background: rgba(255,255,255,0.6);
   border-radius: 50%;
   z-index: 0;
+  backdrop-filter: blur(2px);
 }
 
 .resource-bar .resource-circle span {
@@ -174,7 +234,8 @@ font-weight: bold;
 .quick-nav {
   display: flex;
   justify-content: space-around;
-  background: #34495e;
+  background: rgba(52, 73, 94, 0.8);
+  backdrop-filter: blur(8px);
   padding: 0.5rem;
   position: sticky;
   top: 0;
@@ -186,15 +247,17 @@ font-weight: bold;
   text-decoration: none;
   font-weight: bold;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.15rem;
+  font-size: 0.9rem;
 }
 
 .quick-nav .icon {
-  display: none;
+  font-size: 1.4rem;
 }
 .quick-nav .label {
-  display: inline;
+  display: block;
 }
 
 .save-load {
@@ -777,15 +840,14 @@ main {
 
 
 
-  .stats {
+  .header-cards {
     justify-content: center;
   }
 
   .quick-nav .label {
-    display: none;
+    display: block;
   }
   .quick-nav .icon {
-    display: inline;
     font-size: 1.2rem;
   }
   .quick-nav .top-next-month {

--- a/uiManager.js
+++ b/uiManager.js
@@ -16,15 +16,24 @@ export class UIManager {
     };
   }
 
+  pulse(el) {
+    if (!el) return;
+    const target = el.closest('.stat-card') || el;
+    target.classList.add('pulse');
+    setTimeout(() => target.classList.remove('pulse'), 500);
+  }
+
   updateMonth(month) {
     if (this.elements.month) {
       this.elements.month.textContent = month;
+      this.pulse(this.elements.month);
     }
   }
 
   updateLevel(level) {
     if (this.elements.level) {
       this.elements.level.textContent = level;
+      this.pulse(this.elements.level);
     }
   }
 
@@ -35,6 +44,9 @@ export class UIManager {
     if (prog) {
       prog.max = next;
       prog.value = xp;
+      prog.classList.add('shimmer');
+      this.pulse(prog);
+      setTimeout(() => prog.classList.remove('shimmer'), 1000);
     }
   }
 
@@ -49,6 +61,7 @@ export class UIManager {
       else if (val < 50) face = '😟';
       else if (val < 75) face = '🙂';
       this.elements.morale.textContent = `${face} ${val}`;
+      this.pulse(this.elements.morale);
     }
   }
 }


### PR DESCRIPTION
## Summary
- overhaul header markup with stat cards and resource cards
- add glassmorphism styles, animations and mobile optimizations
- color-code resources consistently
- add pulsing animations on stat updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686311bda62483208b6c55f9afd34506