### PR TITLE
Condense quick nav bar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -350,10 +350,10 @@ header h1 {
 .quick-nav {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.5rem;
+  gap: 0.25rem;
   background: rgba(52, 73, 94, 0.9);
-  backdrop-filter: blur(15px);
-  padding: 0.75rem;
+  backdrop-filter: blur(12px);
+  padding: 0.25rem;
   border-radius: 0 0 12px 12px;
 }
 
@@ -362,16 +362,16 @@ header h1 {
   text-decoration: none;
   font-weight: 600;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
   gap: 0.25rem;
-  padding: 0.75rem 0.5rem;
-  border-radius: 10px;
-  transition: all 0.3s ease;
+  padding: 0.25rem;
+  border-radius: 8px;
+  transition: all 0.2s ease;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  min-height: 70px;
+  min-height: 32px;
 }
 
 .quick-nav a:hover,
@@ -386,14 +386,13 @@ header h1 {
 }
 
 .quick-nav .icon {
-  font-size: 1.5rem;
+  font-size: 1rem;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
 }
 
 .quick-nav .label {
-  font-size: 0.8rem;
-  text-align: center;
-  line-height: 1.2;
+  font-size: 0.7rem;
+  line-height: 1;
 }
 
 /* Pulse Animation */
@@ -428,20 +427,20 @@ header h1 {
   .quick-nav {
     grid-template-columns: repeat(4, 1fr);
     gap: 0.25rem;
-    padding: 0.5rem;
+    padding: 0.25rem;
   }
-  
+
   .quick-nav a {
-    padding: 0.5rem 0.25rem;
-    min-height: 60px;
+    padding: 0.25rem;
+    min-height: 32px;
   }
-  
+
   .quick-nav .label {
     font-size: 0.7rem;
   }
-  
+
   .quick-nav .icon {
-    font-size: 1.2rem;
+    font-size: 1rem;
   }
   
   .resource-bar {
@@ -1028,9 +1027,9 @@ main {
   .quick-nav .label {
     display: block;
   }
-  .quick-nav .icon {
-    font-size: 1.2rem;
-  }
+    .quick-nav .icon {
+      font-size: 1rem;
+    }
   .quick-nav .top-next-month {
     display: none;
   }


### PR DESCRIPTION
## Summary
- shrink quick nav grid and item padding
- set nav items to align icon and label horizontally
- use smaller icons and text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686341ee098483208df793b1fee91fbd