### PR TITLE
Fix building unlock after level-up

### DIFF
--- a/index.html
+++ b/index.html
@@ -1298,11 +1298,16 @@
 
         function gainXP(amount) {
             gameState.xp += amount;
+            let leveledUp = false;
             while (gameState.xp >= gameState.xpToNext) {
                 gameState.xp -= gameState.xpToNext;
                 gameState.level++;
                 gameState.xpToNext = Math.floor(gameState.xpToNext * 1.2);
                 addLogEntry(`🎉 Level up! You are now level ${gameState.level}!`, 'success');
+                leveledUp = true;
+            }
+            if (leveledUp) {
+                initializeBuildings();
             }
         }
 


### PR DESCRIPTION
## Summary
- when gaining XP, detect level-ups
- refresh building list on level-up so new buildings become available immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686446a677808320b525a016b00ca4db