### PR TITLE
Fix exploration rewards and button updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1555,8 +1555,9 @@
             }
             
             gameState.explorationsLeft--;
-            showDiceRoll(() => {
-                const roll = Math.floor(Math.random() * 20) + 1;
+            updateUI();
+            initializeLocations();
+            showDiceRoll((roll) => {
                 let result = '';
                 let type = 'neutral';
                 let rewards = {};
@@ -1797,8 +1798,7 @@
             gameState.resources.tools += prod.tools;
             gameState.resources.gems += prod.gems;
             
-            showDiceRoll(() => {
-                const roll = Math.floor(Math.random() * 20) + 1;
+            showDiceRoll((roll) => {
                 let event = '';
                 let type = 'neutral';
                 
@@ -1844,8 +1844,8 @@
                 dice.classList.remove('rolling');
                 const roll = Math.floor(Math.random() * 20) + 1;
                 diceFace.textContent = roll;
-                
-                const details = callback ? callback() : [`You rolled ${roll}`];
+
+                const details = callback ? callback(roll) : [`You rolled ${roll}`];
                 result.innerHTML = details.join('<br>');
             }, 1000);
         }


### PR DESCRIPTION
## Summary
- fix `showDiceRoll` to pass the dice roll value to callbacks
- disable exploration buttons immediately when a location is explored
- adjust monthly advance code to use the roll from `showDiceRoll`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686468824c38832083c2d382e53a22d7