### PR TITLE
Fix exploration roll messages

### DIFF
--- a/dice.js
+++ b/dice.js
@@ -52,6 +52,9 @@ export function showDiceRoll(callback) {
     } else if (detail) {
       lines.push(detail);
     }
+    if (lines.length === 1) {
+      lines.push('No effect');
+    }
 
     result.innerHTML = lines.join('<br>');
   }, 1000);

--- a/index.html
+++ b/index.html
@@ -1548,36 +1548,42 @@
                 addLogEntry('❌ No explorations remaining this month!', 'failure');
                 return;
             }
-            
+
             if (gameState.level < location.level) {
                 addLogEntry(`❌ Need level ${location.level} to explore ${location.name}`, 'failure');
                 return;
             }
-            
+
             gameState.explorationsLeft--;
             showDiceRoll((roll) => {
                 let result = '';
                 let type = 'neutral';
                 let rewards = {};
+                let quality = '';
                 
                 // Different rewards based on location and roll
                 if (roll === 1) {
+                    quality = 'Critical Failure';
                     result = `💀 Critical failure at ${location.name}! You lost 1 food and gained nothing.`;
                     type = 'failure';
                     gameState.resources.food = Math.max(0, gameState.resources.food - 1);
                 } else if (roll >= 18) {
+                    quality = 'Great Success';
                     result = `✨ Amazing success at ${location.name}! Double rewards!`;
                     type = 'success';
                     rewards = getLocationRewards(key, 2.0);
                 } else if (roll >= 12) {
+                    quality = 'Success';
                     result = `⭐ Good results at ${location.name}!`;
                     type = 'success';
                     rewards = getLocationRewards(key, 1.5);
                 } else if (roll >= 6) {
+                    quality = 'Decent';
                     result = `📦 Decent exploration at ${location.name}.`;
                     type = 'neutral';
                     rewards = getLocationRewards(key, 1.0);
                 } else {
+                    quality = 'Poor';
                     result = `😞 Poor exploration at ${location.name}.`;
                     type = 'failure';
                     rewards = getLocationRewards(key, 0.5);
@@ -1604,9 +1610,9 @@
                 addLogEntry(logMessage, type);
                 updateUI();
                 initializeLocations(); // Refresh location buttons
-                
+
                 return [
-                    result,
+                    `${quality}: ${result}`,
                     rewardText ? `Rewards: ${rewardText}` : 'No rewards gained',
                     `Explorations remaining: ${gameState.explorationsLeft}`
                 ];
@@ -1844,11 +1850,14 @@
                 diceFace.textContent = roll;
 
                 const lines = [`You rolled ${roll}`];
-                let detail = callback ? callback(roll) : null;
+                const detail = callback ? callback(roll) : null;
                 if (Array.isArray(detail)) {
                     lines.push(...detail);
                 } else if (detail) {
                     lines.push(detail);
+                }
+                if (lines.length === 1) {
+                    lines.push('No effect');
                 }
                 result.innerHTML = lines.join('<br>');
             }, 1000);


### PR DESCRIPTION
## Summary
- show detailed outcome in dice modal
- improve exploration results messaging so resources are clearer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68647c78f2148320add480a21bedd37a