### PR TITLE
Fix dice roll detail display

### DIFF
--- a/app.js
+++ b/app.js
@@ -661,7 +661,8 @@ function calculateExplorationResult(locationKey, roll) {
             rewards: { food: -1 },
             xp: 5,
             message,
-            type
+            type,
+            roll: effectiveRoll
         };
     } else if (effectiveRoll >= 18) {
         multiplier = 2;

--- a/dice.js
+++ b/dice.js
@@ -44,7 +44,12 @@ export function showDiceRoll(callback) {
 
     let detail = '';
     if (callback) {
-      detail = callback(roll) || '';
+      try {
+        detail = callback(roll) || '';
+      } catch (err) {
+        console.error('Dice roll callback error:', err);
+        detail = 'An error occurred';
+      }
     }
 
     if (Array.isArray(detail)) {


### PR DESCRIPTION
## Summary
- add roll value to critical failure results so display doesn't break
- guard dice roll callbacks with try/catch to avoid losing roll results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864814f9800832088faffb9fba7e1a0