### PR TITLE
Add in-browser error logging

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -62,5 +62,6 @@ export const gameState = {
         reward: 50,
         completed: false
     },
-    eventLog: []
+    eventLog: [],
+    errorLog: []
 };

--- a/index.html
+++ b/index.html
@@ -896,8 +896,22 @@
                 </div>
                 <div class="section-content">
                     <div class="log-container" id="event-log">
-                        <!-- Log entries will be populated by JavaScript -->
+                        <div id="event-log-content"></div>
                     </div>
+                    <button id="clear-log-btn" class="upgrade-button" style="margin-top: var(--spacing-sm);">Clear Log</button>
+                </div>
+            </div>
+
+            <!-- Error Log Section -->
+            <div class="section">
+                <div class="section-header">
+                    <h2 class="section-title">🐞 Error Log</h2>
+                </div>
+                <div class="section-content">
+                    <div class="log-container" id="error-log">
+                        <div id="error-log-content"></div>
+                    </div>
+                    <button id="clear-error-log" class="upgrade-button" style="margin-top: var(--spacing-sm);">Clear Errors</button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- track runtime errors in `gameState`
- create UI section to display errors
- hook up global error handlers and clearing logic
- include buttons to clear event log and error log

## Testing
- `node --check app.js`
- `node --check gameState.js`

------
https://chatgpt.com/codex/tasks/task_e_6865682e75948320b0a858ce6d8683f4