### PR TITLE
Fix bottom resource bar layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -1792,17 +1792,18 @@ function updateErrorLogUI() {
 function setupResourceBar() {
     const bar = document.getElementById('resource-bar');
     if (!bar) return;
-    bar.innerHTML = RESOURCE_TYPES.map(r => {
+    const items = RESOURCE_TYPES.map(r => {
         const icon = getResourceIcon(r);
         const name = r.charAt(0).toUpperCase() + r.slice(1);
         const amount = gameState.resources[r];
         return `
-            <div class="resource" data-resource="${r}" title="${name}">
+            <div class="resource-compact" data-resource="${r}" title="${name}">
                 <div class="resource-icon">${icon}</div>
                 <div class="resource-amount" id="bar-${r}">${amount}</div>
-                <div class="resource-production" id="bar-prod-${r}"></div>
+                <div class="resource-prod" id="bar-prod-${r}"></div>
             </div>`;
     }).join('');
+    bar.innerHTML = `<div class="resources-compact">${items}</div>`;
 }
 
 function updateResourceBar() {


### PR DESCRIPTION
## Summary
- update `setupResourceBar` to use the compact resources layout so items display in a grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686594b412e08320a090d04d0c41e6e1