### PR TITLE
Fix dev panel position and unify upgrade button style

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,6 +556,27 @@
             transition: all 0.3s ease;
         }
 
+        .upgrade-btn {
+            background: linear-gradient(135deg, var(--primary-blue) 0%, var(--primary-purple) 100%);
+            color: var(--white);
+            border: none;
+            border-radius: var(--border-radius-small);
+            padding: var(--spacing-sm) var(--spacing-md);
+            font-size: 0.9rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .upgrade-btn:active {
+            transform: scale(0.95);
+        }
+
+        .upgrade-btn:disabled {
+            background: #bdc3c7;
+            cursor: not-allowed;
+        }
+
         .build-button:active {
             transform: scale(0.95);
         }

--- a/styles.css
+++ b/styles.css
@@ -798,18 +798,21 @@ font-weight: 500;
 
 /* Buttons */
 .upgrade-btn, .build-btn, .craft-btn {
-background: linear-gradient(135deg, var(--primary-blue) 0%, var(--primary-purple) 100%);
-color: white;
-border: none;
-border-radius: 6px;
-padding: 0.5rem 1rem;
-font-size: 0.9rem;
-cursor: pointer;
-transition: all 0.3s ease;
-display: flex;
-flex-direction: column;
-align-items: center;
-min-width: 100px;
+  background: linear-gradient(135deg, var(--primary-blue) 0%, var(--primary-purple) 100%);
+  color: white;
+  border: none;
+  border-radius: var(--border-radius-small);
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.upgrade-btn:active,
+.build-btn:active,
+.craft-btn:active {
+  transform: scale(0.95);
 }
 
 .upgrade-btn:hover:not(:disabled),
@@ -1258,7 +1261,7 @@ padding-bottom: env(safe-area-inset-bottom);
 
 .dev-panel {
   position: fixed;
-  bottom: 4.5rem;
+  top: 5rem;
   right: 1rem;
   background: white;
   border: 1px solid #ccc;


### PR DESCRIPTION
## Summary
- move developer panel to the top right so it isn't hidden by the resource bar
- style `.upgrade-btn` buttons to match the build buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865af0c4f3883209e63fc05859ac35f