### PR TITLE
Add debug panel with logging

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,93 @@
+export let debugMode = false;
+export const eventLog = [];
+
+import { gameState } from './gameState.js';
+import { rollDice } from './dice.js';
+import { BUILDING_TYPES } from './data/buildings.js';
+
+export function setDebugMode(value) {
+  debugMode = value;
+  const panel = document.getElementById('debug-panel');
+  const toggle = document.getElementById('debug-toggle');
+  if (panel) panel.style.display = debugMode ? 'block' : 'none';
+  if (toggle) toggle.style.display = debugMode ? 'block' : 'none';
+}
+
+export function logEvent(description, data = null) {
+  if (!debugMode) return;
+  const entry = {
+    timestamp: new Date().toLocaleTimeString(),
+    description,
+    data
+  };
+  console.log(`[${entry.timestamp}]`, description, data || '');
+  eventLog.push(entry);
+  if (eventLog.length > 200) eventLog.shift();
+  updateLogDisplay();
+}
+
+function updateLogDisplay() {
+  const logArea = document.getElementById('debug-log');
+  if (!logArea) return;
+  const entries = eventLog.slice(-50);
+  logArea.textContent = entries
+    .map(e => `[${e.timestamp}] ${e.description}` + (e.data ? ` ${JSON.stringify(e.data)}` : ''))
+    .join('\n');
+  logArea.scrollTop = logArea.scrollHeight;
+}
+
+export function printGameState() {
+  console.log('Current game state:', JSON.parse(JSON.stringify(gameState)));
+}
+
+export function copyLog() {
+  navigator.clipboard.writeText(JSON.stringify(eventLog, null, 2))
+    .then(() => logEvent('Log copied to clipboard'))
+    .catch(err => console.error('Copy failed', err));
+}
+
+export function runTestScenario() {
+  logEvent('Test scenario started');
+  const roll = rollDice();
+  logEvent(`Rolled a ${roll}`);
+
+  const farm = { id: Date.now(), level: 'basic' };
+  gameState.settlement.farms.push(farm);
+  logEvent('Built Farm', { id: farm.id });
+
+  const nextLevel = BUILDING_TYPES.farm.levels[farm.level].upgradeTo;
+  if (nextLevel) {
+    farm.level = nextLevel;
+    logEvent('Upgraded Farm', { id: farm.id, level: farm.level });
+  } else {
+    logEvent('Farm already at max level');
+  }
+
+  updateLogDisplay();
+}
+
+function setupDebugPanel() {
+  const toggle = document.getElementById('debug-toggle');
+  const panel = document.getElementById('debug-panel');
+  if (toggle) {
+    toggle.addEventListener('click', () => panel.classList.toggle('collapsed'));
+  }
+
+  const testBtn = document.getElementById('debug-test-btn');
+  const copyBtn = document.getElementById('debug-copy-btn');
+  const printBtn = document.getElementById('debug-print-btn');
+
+  if (testBtn) testBtn.addEventListener('click', runTestScenario);
+  if (copyBtn) copyBtn.addEventListener('click', copyLog);
+  if (printBtn) printBtn.addEventListener('click', printGameState);
+
+  setDebugMode(debugMode);
+  updateLogDisplay();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setupDebugPanel);
+} else {
+  setupDebugPanel();
+}
+

--- a/index.html
+++ b/index.html
@@ -796,6 +796,45 @@
         .mt-1 { margin-top: var(--spacing-sm); }
         .mb-1 { margin-bottom: var(--spacing-sm); }
 
+        /* Debug Panel */
+        #debug-panel {
+            position: fixed;
+            bottom: 0.5rem;
+            right: 0.5rem;
+            background: rgba(0,0,0,0.7);
+            color: white;
+            font-family: monospace;
+            padding: var(--spacing-sm);
+            border: 1px solid #5bc0de;
+            border-radius: var(--border-radius-small);
+            width: 250px;
+            z-index: 1002;
+        }
+        #debug-panel.collapsed .debug-content {
+            display: none;
+        }
+        #debug-toggle {
+            background: rgba(0,0,0,0.8);
+            color: white;
+            border: none;
+            cursor: pointer;
+            width: 100%;
+            padding: var(--spacing-xs);
+            font-size: 0.8rem;
+        }
+        #debug-log {
+            height: 120px;
+            overflow-y: auto;
+            background: rgba(255,255,255,0.1);
+            margin-bottom: var(--spacing-sm);
+            white-space: pre-wrap;
+        }
+        .debug-btn {
+            display: block;
+            width: 100%;
+            margin-bottom: var(--spacing-xs);
+        }
+
         /* Responsive adjustments */
         @media (max-width: 380px) {
             .stats-compact {
@@ -1143,6 +1182,17 @@
         </div>
         <button id="dev-toggle-btn" class="dev-toggle">🐞</button>
 
+        <!-- Debug Panel -->
+        <div id="debug-panel" class="debug-panel collapsed">
+            <button id="debug-toggle">Debug Panel</button>
+            <div class="debug-content">
+                <pre id="debug-log"></pre>
+                <button id="debug-test-btn" class="debug-btn">Run Test Scenario</button>
+                <button id="debug-copy-btn" class="debug-btn">Copy Log</button>
+                <button id="debug-print-btn" class="debug-btn">Print Game State</button>
+            </div>
+        </div>
+
         <!-- Resource Bar -->
         <div id="resource-bar" class="resource-bar">
             <div class="resources-compact">
@@ -1206,5 +1256,6 @@
         </div>
     </div>
 <script type="module" src="app.js"></script>
+<script type="module" src="debug.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce a `debug.js` module containing `debugMode`, `logEvent`, and other helpers
- add a collapsible Debug Panel to the interface
- display recent debug events and provide buttons to run a test scenario, copy log, or print game state
- load the new debug module from HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866d68c6bd08320837994ca7ec116ed